### PR TITLE
Fix bilibili live resolution

### DIFF
--- a/src/api/bilibili_live.go
+++ b/src/api/bilibili_live.go
@@ -90,7 +90,7 @@ func (b *BiliBiliLive) GetStreamUrls() (us []*url.URL, err error) {
 	}
 	body, err := http.Get(biliBiliLiveApiUrl, map[string]string{
 		"cid":      b.realId,
-		"quality":  "0",
+		"quality":  "4",
 		"platform": "web",
 	}, nil)
 	if err != nil {


### PR DESCRIPTION
Missing 1080p resolution by default since bilibili updated API according to https://github.com/streamlink/streamlink/pull/2625