### PR TITLE
修复虎牙直播纯数字房间录制失败的问题

### DIFF
--- a/src/live/huya/huya.go
+++ b/src/live/huya/huya.go
@@ -88,7 +88,7 @@ func (l *Live) GetStreamUrls() (us []*url.URL, err error) {
 	}
 
 	// Decode stream part.
-	streamInfo := utils.Match1(`"stream": "(.*?)"`, body)
+	streamInfo := utils.Match1_V2(`"stream": "(.*?)"`, body)
 	if streamInfo == "" {
 		return nil, live.ErrInternalError
 	}

--- a/src/live/huya/huya.go
+++ b/src/live/huya/huya.go
@@ -1,7 +1,6 @@
 package huya
 
 import (
-	"encoding/base64"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -88,15 +87,7 @@ func (l *Live) GetStreamUrls() (us []*url.URL, err error) {
 	}
 
 	// Decode stream part.
-	streamInfo := utils.Match1_V2(`"stream": "(.*?)"`, body)
-	if streamInfo == "" {
-		return nil, live.ErrInternalError
-	}
-	streamByte, err := base64.StdEncoding.DecodeString(streamInfo)
-	if err != nil {
-		return nil, err
-	}
-	streamStr := utils.UnescapeHTMLEntity(string(streamByte))
+	streamStr := utils.Match1(`(?m)stream: (.*?)$`, body)
 
 	var (
 		sStreamName  = utils.Match1(`"sStreamName":"([^"]*)"`, streamStr)

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"crypto/md5"
+	"encoding/base64"
 	"encoding/hex"
 	"math/rand"
 	"net/url"
@@ -45,6 +46,27 @@ func Match1(re, str string) string {
 	match := reg.FindStringSubmatch(str)
 	if match == nil || len(match) < 2 {
 		return ""
+	}
+	return match[1]
+}
+
+func Match1_V2(re, str string) string {
+	reg, err := regexp.Compile(re)
+	if err != nil {
+		return ""
+	}
+	match := reg.FindStringSubmatch(str)
+	if match == nil || len(match) < 2 {
+		reg2, err2 := regexp.Compile("stream: {(.*)}")
+		if err2 != nil {
+			return ""
+		}
+		match2 := reg2.FindStringSubmatch(str)
+		if len(match2) != 2 {
+			return ""
+		}
+		stream_data := "{" + match2[1] + "}"
+		return base64.StdEncoding.EncodeToString([]byte(stream_data))
 	}
 	return match[1]
 }

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"crypto/md5"
-	"encoding/base64"
 	"encoding/hex"
 	"math/rand"
 	"net/url"
@@ -46,27 +45,6 @@ func Match1(re, str string) string {
 	match := reg.FindStringSubmatch(str)
 	if match == nil || len(match) < 2 {
 		return ""
-	}
-	return match[1]
-}
-
-func Match1_V2(re, str string) string {
-	reg, err := regexp.Compile(re)
-	if err != nil {
-		return ""
-	}
-	match := reg.FindStringSubmatch(str)
-	if match == nil || len(match) < 2 {
-		reg2, err2 := regexp.Compile("stream: {(.*)}")
-		if err2 != nil {
-			return ""
-		}
-		match2 := reg2.FindStringSubmatch(str)
-		if len(match2) != 2 {
-			return ""
-		}
-		stream_data := "{" + match2[1] + "}"
-		return base64.StdEncoding.EncodeToString([]byte(stream_data))
 	}
 	return match[1]
 }


### PR DESCRIPTION
前段时间虎牙直播页面更新，纯数字房间录制失败，提示`failed to get stream url, will retry after 5s..." error="internal error"`，我更改了虎牙平台中解析直播信息的方式，现在同时支持字母混合房间和纯数字房间。