### PR TITLE
修改MaxDuration的验证规则以匹配其规则描述

### DIFF
--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -89,7 +89,7 @@ func (c *Config) Verify() error {
 	if _, err := os.Stat(c.OutPutPath); err != nil {
 		return fmt.Errorf(`the out put path: "%s" is not exist`, c.OutPutPath)
 	}
-	if maxDur := c.VideoSplitStrategies.MaxDuration; maxDur > 0 && maxDur <= time.Minute {
+	if maxDur := c.VideoSplitStrategies.MaxDuration; maxDur > 0 && maxDur < time.Minute {
 		return fmt.Errorf("the minimum value of max_duration is one minute")
 	}
 	return nil


### PR DESCRIPTION
根据错误描述，最小的max_duration应允许恰好为1分钟的情况