### PR TITLE
增加录制后转成mp4和转换成功后删除原文件的选项

### DIFF
--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -45,6 +45,12 @@ type VideoSplitStrategies struct {
 	MaxDuration       time.Duration `yaml:"max_duration"`
 }
 
+// On record finished actions.
+type OnRecordFinished struct {
+	ConvertToMp4          bool `yaml:"convert_to_mp4"`
+	DeleteFlvAfterConvert bool `yaml:"delete_flv_after_convert"`
+}
+
 // Config content all config info.
 type Config struct {
 	file string
@@ -58,6 +64,7 @@ type Config struct {
 	OutputTmpl           string               `yaml:"out_put_tmpl"`
 	VideoSplitStrategies VideoSplitStrategies `yaml:"video_split_strategies"`
 	Cookies              map[string]string    `yaml:"cookies"`
+	OnRecordFinished     OnRecordFinished     `yaml:"on_record_finished"`
 }
 
 var defaultConfig = Config{
@@ -72,6 +79,10 @@ var defaultConfig = Config{
 	file:      "",
 	VideoSplitStrategies: VideoSplitStrategies{
 		OnRoomNameChanged: false,
+	},
+	OnRecordFinished: OnRecordFinished{
+		ConvertToMp4:          false,
+		DeleteFlvAfterConvert: false,
 	},
 }
 

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -155,15 +155,7 @@ func (r *recorder) tryRecode() {
 			convertCmd.Process.Kill()
 			r.getLogger().Debugln(err)
 		} else if r.config.OnRecordFinished.DeleteFlvAfterConvert {
-			deleteCmd := exec.Command(
-				"rm",
-				"-rf",
-				fileName,
-			)
-			if err = deleteCmd.Run(); err != nil {
-				deleteCmd.Process.Kill()
-				r.getLogger().Debugln(err)
-			}
+			os.Remove(fileName)
 		}
 	}
 }


### PR DESCRIPTION
这个 PR 应该能解决 https://github.com/hr3lxphr6j/bililive-go/issues/159, #286  的问题。
转换后的文件名后缀为 `.flv.mp4` 是有意为之。看起来不美观的话可以再商量。

第一次写 golang，请严格 review >_<