### PR TITLE
修复抖音录制功能

### DIFF
--- a/src/live/douyin/douyin.go
+++ b/src/live/douyin/douyin.go
@@ -37,7 +37,7 @@ type Live struct {
 }
 
 func (l *Live) getData() (*gjson.Result, error) {
-	resp, err := requests.Get(l.Url.String(), live.CommonUserAgent)
+	resp, err := requests.Get(l.Url.String(), live.CommonUserAgent, requests.Cookie("__ac_nonce", "123456789012345678901"))
 	if err != nil {
 		return nil, err
 	}
@@ -72,9 +72,9 @@ func (l *Live) GetInfo() (info *live.Info, err error) {
 	}
 	info = &live.Info{
 		Live:     l,
-		HostName: data.Get("initialState.roomStore.roomInfo.room.owner.nickname").String(),
-		RoomName: data.Get("initialState.roomStore.roomInfo.room.title").String(),
-		Status:   data.Get("initialState.roomStore.roomInfo.room.status").Int() == 2,
+		HostName: data.Get("app.initialState.roomStore.roomInfo.anchor.nickname").String(),
+		RoomName: data.Get("app.initialState.roomStore.roomInfo.room.title").String(),
+		Status:   data.Get("app.initialState.roomStore.roomInfo.room.status").Int() == 2,
 	}
 	return
 }
@@ -85,7 +85,7 @@ func (l *Live) GetStreamUrls() (us []*url.URL, err error) {
 		return nil, err
 	}
 	var urls []string
-	data.Get("initialState.roomStore.roomInfo.room.stream_url.flv_pull_url").ForEach(func(key, value gjson.Result) bool {
+	data.Get("app.initialState.roomStore.roomInfo.room.stream_url.flv_pull_url").ForEach(func(key, value gjson.Result) bool {
 		urls = append(urls, value.String())
 		return true
 	})


### PR DESCRIPTION
预计修复 #221, #222, #242, #253 等 issue。

不加 cookie 得到的页面是一个70多 kb 的不包含所需信息的页面。这个 response 会带一个 set-cookie 的 response header，然后让页面刷新一次。
第二次的请求带了 cookie，得到的页面信息就正确了。
请求两次取 cookie 是没问题，但毕竟只是个 nonce ，我随便写了一串字符也能得到正确的页面，就这样偷懒了。

取房间信息的 json 除了增加了一层 app 以外，HostName 部分我发现没在直播的房间没有 `app.initialState.roomStore.roomInfo.room.owner` 这个 key，搜了一下 json 里始终存在的房主名在附近，就换成那个始终存在的值了。
这里改完，readme 里支持网站中抖音的 `TODO` 也可以改成 `滋瓷` 了吧。