### PR TITLE
修复无法找到当前目录中的 ffmpeg.exe 的问题

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -3,19 +3,18 @@ package utils
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"math/rand"
 	"net/url"
-	"os"
 	"os/exec"
 	"regexp"
 )
 
 func IsFFmpegExist() bool {
 	_, err := exec.LookPath("ffmpeg")
-	if err != nil {
-		// exec.LookPath no longer searches current directory since golang 1.19,
-		// so we check the current directory separately
-		_, err = os.Stat("ffmpeg")
+	if errors.Is(err, exec.ErrDot) {
+		// put ffmpeg.exe and binary like bililive-windows-amd64.exe to the same folder is allowed
+		err = nil
 	}
 	return err == nil
 }


### PR DESCRIPTION
https://github.com/hr3lxphr6j/bililive-go/pull/298 的修复是错误的，没有实现目的。
现在按照官方[推荐方法](https://pkg.go.dev/os/exec@master#hdr-Executables_in_the_current_directory)重新修复一遍，并再次 fix https://github.com/hr3lxphr6j/bililive-go/issues/248