### PR TITLE
v0.6.7 的补充修改

### DIFF
--- a/src/pkg/parser/ffmpeg/ffmpeg.go
+++ b/src/pkg/parser/ffmpeg/ffmpeg.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hr3lxphr6j/bililive-go/src/live"
 	"github.com/hr3lxphr6j/bililive-go/src/pkg/parser"
+	"github.com/hr3lxphr6j/bililive-go/src/pkg/utils"
 )
 
 const (
@@ -119,8 +120,12 @@ func (p *Parser) Status() (map[string]string, error) {
 }
 
 func (p *Parser) ParseLiveStream(url *url.URL, live live.Live, file string) (err error) {
+	ffmpegPath, err := utils.GetFFmpegPath()
+	if err != nil {
+		return err
+	}
 	p.cmd = exec.Command(
-		"ffmpeg",
+		ffmpegPath,
 		"-nostats",
 		"-progress", "-",
 		"-y", "-re",

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -10,12 +10,17 @@ import (
 	"regexp"
 )
 
-func IsFFmpegExist() bool {
-	_, err := exec.LookPath("ffmpeg")
+func GetFFmpegPath() (string, error) {
+	path, err := exec.LookPath("ffmpeg")
 	if errors.Is(err, exec.ErrDot) {
 		// put ffmpeg.exe and binary like bililive-windows-amd64.exe to the same folder is allowed
-		err = nil
+		path, err = exec.LookPath("./ffmpeg")
 	}
+	return path, err
+}
+
+func IsFFmpegExist() bool {
+	_, err := GetFFmpegPath()
 	return err == nil
 }
 

--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -142,8 +142,13 @@ func (r *recorder) tryRecode() {
 	r.getLogger().Debugln(r.parser.ParseLiveStream(url, r.Live, fileName))
 	removeEmptyFile(fileName)
 	if r.config.OnRecordFinished.ConvertToMp4 {
+		ffmpegPath, err := utils.GetFFmpegPath()
+		if err != nil {
+			r.getLogger().WithError(err).Error("failed to find ffmpeg")
+			return
+		}
 		convertCmd := exec.Command(
-			"ffmpeg",
+			ffmpegPath,
 			"-hide_banner",
 			"-i",
 			fileName,


### PR DESCRIPTION
https://github.com/hr3lxphr6j/bililive-go/pull/308 只修复了判断 ffmpeg 是否存在的逻辑。
这次补充了执行 ffmpeg 时的逻辑，否则当 ffmpeg 在当前目录时，检测 ffmpeg 可以通过，但执行 ffmpeg 却会崩溃。

说起来，崩溃处在[这里](https://github.com/hr3lxphr6j/bililive-go/blob/v0.6.7/src/pkg/parser/ffmpeg/ffmpeg.go#L146)，看起来又是另一个潜在的 bug 了。。