### PR TITLE
增加开启/停止自动录制并在配置文件里记忆开关状态

### DIFF
--- a/src/cmd/bililive/bililive.go
+++ b/src/cmd/bililive/bililive.go
@@ -70,7 +70,7 @@ func main() {
 
 	inst.Lives = make(map[live.ID]live.Live)
 	for _, room := range inst.Config.LiveRooms {
-		u, err := url.Parse(room)
+		u, err := url.Parse(room.Url)
 		if err != nil {
 			logger.WithField("url", room).Error(err)
 			continue

--- a/src/cmd/bililive/bililive.go
+++ b/src/cmd/bililive/bililive.go
@@ -110,8 +110,15 @@ func main() {
 	}
 
 	for _, _live := range inst.Lives {
-		if err := lm.AddListener(ctx, _live); err != nil {
-			logger.WithFields(map[string]interface{}{"url": _live.GetRawUrl()}).Error(err)
+		room, err := inst.Config.GetLiveRoomByUrl(_live.GetRawUrl())
+		if err != nil {
+			logger.WithFields(map[string]interface{}{"room": _live.GetRawUrl()}).Error(err)
+			panic(err)
+		}
+		if room.IsListening {
+			if err := lm.AddListener(ctx, _live); err != nil {
+				logger.WithFields(map[string]interface{}{"url": _live.GetRawUrl()}).Error(err)
+			}
 		}
 		time.Sleep(time.Second * 5)
 	}

--- a/src/cmd/bililive/internal/flag/flag.go
+++ b/src/cmd/bililive/internal/flag/flag.go
@@ -41,7 +41,7 @@ func GenConfigFromFlags() *configs.Config {
 		Interval:   *Interval,
 		OutPutPath: *Output,
 		OutputTmpl: *OutputFileTmpl,
-		LiveRooms:  *Input,
+		LiveRooms:  configs.NewLiveRoomsWithStrings(*Input),
 		Feature: configs.Feature{
 			UseNativeFlvParser: *NativeFlvParser,
 		},

--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -70,7 +70,7 @@ type Config struct {
 
 type LiveRoom struct {
 	Url         string `yaml:"url"`
-	IsRecording bool   `yaml:"is_recording"`
+	IsListening bool   `yaml:"is_listening"`
 }
 
 type liveRoomAlias LiveRoom
@@ -78,7 +78,7 @@ type liveRoomAlias LiveRoom
 // allow both string and LiveRoom format in config
 func (l *LiveRoom) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	liveRoomAlias := liveRoomAlias{
-		IsRecording: true,
+		IsListening: true,
 	}
 	if err := unmarshal(&liveRoomAlias); err != nil {
 		var url string
@@ -99,7 +99,7 @@ func NewLiveRoomsWithStrings(strings []string) []LiveRoom {
 	liveRooms := make([]LiveRoom, len(strings))
 	for index, url := range strings {
 		liveRooms[index].Url = url
-		liveRooms[index].IsRecording = true
+		liveRooms[index].IsListening = true
 	}
 	return liveRooms
 }

--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -128,7 +128,7 @@ func putConfig(writer http.ResponseWriter, r *http.Request) {
 	for _, live := range instance.GetInstance(r.Context()).Lives {
 		configRoom = append(configRoom, configs.LiveRoom{
 			Url:         live.GetRawUrl(),
-			IsRecording: true,
+			IsListening: true,
 		})
 	}
 	instance.GetInstance(r.Context()).Config.LiveRooms = configRoom

--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/tidwall/gjson"
 
+	"github.com/hr3lxphr6j/bililive-go/src/configs"
 	"github.com/hr3lxphr6j/bililive-go/src/consts"
 	"github.com/hr3lxphr6j/bililive-go/src/instance"
 	"github.com/hr3lxphr6j/bililive-go/src/listeners"
@@ -76,8 +77,11 @@ func parseLiveAction(writer http.ResponseWriter, r *http.Request) {
 	writeJSON(writer, parseInfo(r.Context(), live))
 }
 
-/* Post data example
+/*
+	Post data example
+
 [
+
 	{
 		"url": "http://live.bilibili.com/1030",
 		"listen": true
@@ -86,6 +90,7 @@ func parseLiveAction(writer http.ResponseWriter, r *http.Request) {
 		"url": "https://live.bilibili.com/493",
 		"listen": true
 	}
+
 ]
 */
 func addLives(writer http.ResponseWriter, r *http.Request) {
@@ -119,10 +124,12 @@ func getConfig(writer http.ResponseWriter, r *http.Request) {
 }
 
 func putConfig(writer http.ResponseWriter, r *http.Request) {
-	configRoom := instance.GetInstance(r.Context()).Config.LiveRooms
-	configRoom = make([]string, 0, 4)
+	configRoom := make([]configs.LiveRoom, 0, 4)
 	for _, live := range instance.GetInstance(r.Context()).Lives {
-		configRoom = append(configRoom, live.GetRawUrl())
+		configRoom = append(configRoom, configs.LiveRoom{
+			Url:         live.GetRawUrl(),
+			IsRecording: true,
+		})
 	}
 	instance.GetInstance(r.Context()).Config.LiveRooms = configRoom
 	if err := instance.GetInstance(r.Context()).Config.Marshal(); err != nil {

--- a/src/servers/handler.go
+++ b/src/servers/handler.go
@@ -59,16 +59,25 @@ func parseLiveAction(writer http.ResponseWriter, r *http.Request) {
 		writeMsg(writer, http.StatusNotFound, fmt.Sprintf("live id: %s can not find", vars["id"]))
 		return
 	}
+	room, err := inst.Config.GetLiveRoomByUrl(live.GetRawUrl())
+	if err != nil {
+		writeMsg(writer, http.StatusNotFound, fmt.Sprintf("room : %s can not find", live.GetRawUrl()))
+		return
+	}
 	switch vars["action"] {
 	case "start":
 		if err := inst.ListenerManager.(listeners.Manager).AddListener(r.Context(), live); err != nil {
 			writeMsg(writer, http.StatusBadRequest, err.Error())
 			return
+		} else {
+			room.IsListening = true
 		}
 	case "stop":
 		if err := inst.ListenerManager.(listeners.Manager).RemoveListener(r.Context(), live.GetLiveId()); err != nil {
 			writeMsg(writer, http.StatusBadRequest, err.Error())
 			return
+		} else {
+			room.IsListening = false
 		}
 	default:
 		writeMsg(writer, http.StatusBadRequest, fmt.Sprintf("invalid Action: %s", vars["action"]))
@@ -94,28 +103,48 @@ func parseLiveAction(writer http.ResponseWriter, r *http.Request) {
 ]
 */
 func addLives(writer http.ResponseWriter, r *http.Request) {
-	b, _ := ioutil.ReadAll(r.Body)
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		writeJSON(writer, map[string]interface{}{
+			"error": err.Error(),
+		})
+		return
+	}
 	info := liveSlice(make([]*live.Info, 0))
+	errorMessages := make([]string, 0, 4)
 	gjson.ParseBytes(b).ForEach(func(key, value gjson.Result) bool {
 		isListen := value.Get("listen").Bool()
 		urlStr := strings.Trim(value.Get("url").String(), " ")
 		if !strings.HasPrefix(urlStr, "http://") && !strings.HasPrefix(urlStr, "https://") {
 			urlStr = "https://" + urlStr
 		}
-		u, _ := url.Parse(urlStr)
-		if live, err := live.New(u, instance.GetInstance(r.Context()).Cache); err == nil {
+		u, err := url.Parse(urlStr)
+		if err != nil {
+			errorMessages = append(errorMessages, "can't parse url: "+urlStr)
+			return true
+		}
+		if newLive, err := live.New(u, instance.GetInstance(r.Context()).Cache); err == nil {
 			inst := instance.GetInstance(r.Context())
-			if _, ok := inst.Lives[live.GetLiveId()]; !ok {
-				inst.Lives[live.GetLiveId()] = live
+			if _, ok := inst.Lives[newLive.GetLiveId()]; !ok {
+				inst.Lives[newLive.GetLiveId()] = newLive
 				if isListen {
-					inst.ListenerManager.(listeners.Manager).AddListener(r.Context(), live)
+					inst.ListenerManager.(listeners.Manager).AddListener(r.Context(), newLive)
 				}
-				info = append(info, parseInfo(r.Context(), live))
+				info = append(info, parseInfo(r.Context(), newLive))
+
+				liveRoom := configs.LiveRoom{
+					Url:         u.String(),
+					IsListening: isListen,
+				}
+				inst.Config.LiveRooms = append(inst.Config.LiveRooms, liveRoom)
 			}
+		} else {
+			errorMessages = append(errorMessages, err.Error())
 		}
 		return true
 	})
 	sort.Sort(info)
+	// TODO return error messages too
 	writeJSON(writer, info)
 }
 
@@ -124,15 +153,9 @@ func getConfig(writer http.ResponseWriter, r *http.Request) {
 }
 
 func putConfig(writer http.ResponseWriter, r *http.Request) {
-	configRoom := make([]configs.LiveRoom, 0, 4)
-	for _, live := range instance.GetInstance(r.Context()).Lives {
-		configRoom = append(configRoom, configs.LiveRoom{
-			Url:         live.GetRawUrl(),
-			IsListening: true,
-		})
-	}
-	instance.GetInstance(r.Context()).Config.LiveRooms = configRoom
-	if err := instance.GetInstance(r.Context()).Config.Marshal(); err != nil {
+	config := instance.GetInstance(r.Context()).Config
+	config.RefreshLiveRoomIndexCache()
+	if err := config.Marshal(); err != nil {
 		writeMsg(writer, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -155,6 +178,7 @@ func removeLive(writer http.ResponseWriter, r *http.Request) {
 		}
 	}
 	delete(inst.Lives, live.GetLiveId())
+	inst.Config.RemoveLiveRoomByUrl(live.GetRawUrl())
 	writeMsg(writer, http.StatusOK, "OK")
 }
 


### PR DESCRIPTION
目标是 fix https://github.com/hr3lxphr6j/bililive-go/issues/255

在配置文件中用
```
live_rooms:
- url: https://www.douyu.com/1234
  is_listening: false
- url: https://www.huya.com/5678
  is_listening: true
- https://www.huya.com/9012
```
这样详略均可的方式设置录制的房间

- [x] 可以以字符串或格式化形式读写配置文件中的 `live_rooms`
- [x] 使 `is_listening` flag 实际生效