### PR TITLE
双击执行时尝试使用可执行文件旁边的配置文件

### DIFF
--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -152,6 +152,9 @@ func (c *Config) Verify() error {
 	if maxDur := c.VideoSplitStrategies.MaxDuration; maxDur > 0 && maxDur < time.Minute {
 		return fmt.Errorf("the minimum value of max_duration is one minute")
 	}
+	if !c.RPC.Enable && len(c.LiveRooms) == 0 {
+		return fmt.Errorf("the RPC is not enabled, and no live room is set. the program has nothing to do using this setting")
+	}
 	return nil
 }
 

--- a/src/configs/config_test.go
+++ b/src/configs/config_test.go
@@ -28,6 +28,7 @@ func TestConfig_Verify(t *testing.T) {
 	var cfg *Config
 	assert.Error(t, cfg.Verify())
 	cfg = &Config{
+		RPC:        defaultRPC,
 		Interval:   30,
 		OutPutPath: os.TempDir(),
 	}
@@ -36,5 +37,8 @@ func TestConfig_Verify(t *testing.T) {
 	assert.Error(t, cfg.Verify())
 	cfg.Interval = 30
 	cfg.OutPutPath = "foobar"
+	assert.Error(t, cfg.Verify())
+	cfg.OutPutPath = os.TempDir()
+	cfg.RPC.Enable = false
 	assert.Error(t, cfg.Verify())
 }


### PR DESCRIPTION
fix https://github.com/hr3lxphr6j/bililive-go/issues/319

双击执行时尝试使用可执行文件旁边的配置文件，当命令行参数不足且可执行文件旁边没有默认的配置文件时，程序自动退出时会提示退出原因。