### PR TITLE
增加错误提示信息，支持添加斗鱼被封禁房间

### DIFF
--- a/src/webapp/src/utils/common.ts
+++ b/src/webapp/src/utils/common.ts
@@ -112,7 +112,7 @@ class Utils {
     static timestampToHumanReadable(timestamp: number): string {
         const date = new Date(timestamp * 1000);
         const year = date.getFullYear().toString().padStart(4, "0");
-        const month = date.getMonth().toString().padStart(2, "0");
+        const month = (date.getMonth() + 1).toString().padStart(2, "0");
         const day = date.getDate().toString().padStart(2, "0");
         const hour = date.getHours().toString().padStart(2, "0");
         const min = date.getMinutes().toString().padStart(2, "0");


### PR DESCRIPTION
![image](https://github.com/hr3lxphr6j/bililive-go/assets/18671570/21307df0-c8be-4bec-9ae3-b2d4b3d09901)
对未开放的房间返回live.ErrRoomNotExist，例如https://www.douyu.com/5234234
对于被封禁的房间，主播名和房间名均返回“您观看的房间已被关闭"，例如https://www.douyu.com/74741
#450 