### PR TITLE
启动时获取不到直播间信息也在监控列表中保持直播间

### DIFF
--- a/src/cmd/bililive/internal/init.go
+++ b/src/cmd/bililive/internal/init.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/hr3lxphr6j/bililive-go/src/live/missevan"
 	_ "github.com/hr3lxphr6j/bililive-go/src/live/openrec"
 	_ "github.com/hr3lxphr6j/bililive-go/src/live/qq"
+	_ "github.com/hr3lxphr6j/bililive-go/src/live/system"
 	_ "github.com/hr3lxphr6j/bililive-go/src/live/twitch"
 	_ "github.com/hr3lxphr6j/bililive-go/src/live/yizhibo"
 	_ "github.com/hr3lxphr6j/bililive-go/src/live/zhanqi"

--- a/src/listeners/event.go
+++ b/src/listeners/event.go
@@ -5,9 +5,10 @@ import (
 )
 
 const (
-	ListenStart     events.EventType = "ListenStart"
-	ListenStop      events.EventType = "ListenStop"
-	LiveStart       events.EventType = "LiveStart"
-	LiveEnd         events.EventType = "LiveEnd"
-	RoomNameChanged events.EventType = "RoomNameChanged"
+	ListenStart              events.EventType = "ListenStart"
+	ListenStop               events.EventType = "ListenStop"
+	LiveStart                events.EventType = "LiveStart"
+	LiveEnd                  events.EventType = "LiveEnd"
+	RoomNameChanged          events.EventType = "RoomNameChanged"
+	RoomInitializingFinished events.EventType = "RoomInitializingFinished"
 )

--- a/src/listeners/manager_test.go
+++ b/src/listeners/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hr3lxphr6j/bililive-go/src/instance"
 	"github.com/hr3lxphr6j/bililive-go/src/live"
 	livemock "github.com/hr3lxphr6j/bililive-go/src/live/mock"
+	evtmock "github.com/hr3lxphr6j/bililive-go/src/pkg/events/mock"
 )
 
 func TestManagerAddAndRemoveListener(t *testing.T) {
@@ -46,7 +47,9 @@ func TestManagerAddAndRemoveListener(t *testing.T) {
 func TestManagerStartAndClose(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+	ed := evtmock.NewMockDispatcher(ctrl)
 	ctx := context.WithValue(context.Background(), instance.Key, &instance.Instance{
+		EventDispatcher: ed,
 		Config: &configs.Config{
 			RPC: configs.RPC{Enable: true},
 		},

--- a/src/listeners/manager_test.go
+++ b/src/listeners/manager_test.go
@@ -48,6 +48,7 @@ func TestManagerStartAndClose(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	ed := evtmock.NewMockDispatcher(ctrl)
+	ed.EXPECT().AddEventListener(RoomInitializingFinished, gomock.Any())
 	ctx := context.WithValue(context.Background(), instance.Key, &instance.Instance{
 		EventDispatcher: ed,
 		Config: &configs.Config{

--- a/src/live/info.go
+++ b/src/live/info.go
@@ -5,10 +5,12 @@ import (
 )
 
 type Info struct {
-	Live                         Live
-	HostName, RoomName           string
-	Status, Listening, Recording bool
-	CustomLiveId                 string
+	Live                 Live
+	HostName, RoomName   string
+	Status               bool // means isLiving, maybe better to rename it
+	Listening, Recording bool
+	Initializing         bool
+	CustomLiveId         string
 }
 
 func (i *Info) MarshalJSON() ([]byte, error) {
@@ -21,6 +23,7 @@ func (i *Info) MarshalJSON() ([]byte, error) {
 		Status            bool   `json:"status"`
 		Listening         bool   `json:"listening"`
 		Recording         bool   `json:"recording"`
+		Initializing      bool   `json:"initializing"`
 		LastStartTime     string `json:"last_start_time,omitempty"`
 		LastStartTimeUnix int64  `json:"last_start_time_unix,omitempty"`
 	}{
@@ -32,6 +35,7 @@ func (i *Info) MarshalJSON() ([]byte, error) {
 		Status:         i.Status,
 		Listening:      i.Listening,
 		Recording:      i.Recording,
+		Initializing:   i.Initializing,
 	}
 	if !i.Live.GetLastStartTime().IsZero() {
 		t.LastStartTime = i.Live.GetLastStartTime().Format("2006-01-02 15:04:05")

--- a/src/live/system/initializing_live.go
+++ b/src/live/system/initializing_live.go
@@ -1,0 +1,48 @@
+package system
+
+import (
+	"net/url"
+
+	"github.com/hr3lxphr6j/bililive-go/src/live"
+	"github.com/hr3lxphr6j/bililive-go/src/live/internal"
+)
+
+func init() {
+	live.InitializingLiveBuilderInstance = new(builder)
+}
+
+type builder struct{}
+
+func (b *builder) Build(live live.Live, url *url.URL, opt ...live.Option) (live.Live, error) {
+	return &InitializingLive{
+		BaseLive:     internal.NewBaseLive(url, opt...),
+		OriginalLive: live,
+	}, nil
+}
+
+type InitializingLive struct {
+	internal.BaseLive
+	OriginalLive live.Live
+}
+
+func (l *InitializingLive) GetInfo() (info *live.Info, err error) {
+	err = nil
+	info = &live.Info{
+		Live:         l,
+		HostName:     "",
+		RoomName:     l.GetRawUrl(),
+		Status:       false,
+		Initializing: true,
+	}
+	return
+}
+
+func (l *InitializingLive) GetStreamUrls() (us []*url.URL, err error) {
+	us = make([]*url.URL, 0)
+	err = nil
+	return
+}
+
+func (l *InitializingLive) GetPlatformCNName() string {
+	return ""
+}

--- a/src/webapp/src/component/live-list/index.tsx
+++ b/src/webapp/src/component/live-list/index.tsx
@@ -58,6 +58,9 @@ class LiveList extends React.Component<Props, IState> {
                     if (tag === '录制中') {
                         color = 'red';
                     }
+                    if (tag === '初始化') {
+                        color = 'orange';
+                    }
 
                     return (
                         <Tag color={color} key={tag}>
@@ -232,6 +235,10 @@ class LiveList extends React.Component<Props, IState> {
 
                     if (item.recording === true) {
                         tags = ['录制中'];
+                    }
+
+                    if (item.initializing === true) {
+                        tags.push('初始化')
                     }
 
                     return {


### PR DESCRIPTION
最近抖音录制突然大面积失效，症状之一是 config 文件中的抖音直播间不出现在网页版监控列表里。
这个 PR 用于修复直播间不出现在网页版监控列表的问题。