### PR TITLE
修复Platform: freebsd, Arch: 386, GoVersion: 1.19.11 的编译错误

### DIFF
--- a/src/live/yy/yy.go
+++ b/src/live/yy/yy.go
@@ -101,8 +101,8 @@ func (l *Live) getRoomInfo() ([]byte, error) {
 	roomid := paths[1]
 	l.roomID = roomid
 
-	uid := 1125e4*rand.Int() + 4283717296
-	tmp := &data{Id: roomid, Uid: strconv.Itoa(uid)}
+	uid := int64(1125e4*rand.Int()) + int64(4283717296)
+	tmp := &data{Id: roomid, Uid: strconv.FormatInt(int64(uid), 10)}
 
 	tmpl, err := template.New("roomurlteml").Parse(roomInitUrl)
 	if err != nil {


### PR DESCRIPTION
错误信息见这个 action job：https://github.com/hr3lxphr6j/bililive-go/actions/runs/5688823263/job/15419302056#step:8:91

本地编译信息：
```
$ GOOS=freebsd GOARCH=386 CGO_ENABLED=0 UPX_ENABLE=0 TAGS=dev ./src/hack/build.sh bililive
# github.com/hr3lxphr6j/bililive-go/src/live/yy
src/live/yy/yy.go:104:29: 4283717296 (untyped int constant) overflows int
```