### PR TITLE
允许在录制完成后执行自定义命令

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -29,4 +29,11 @@ cookies: {}
 on_record_finished:
   convert_to_mp4: false
   delete_flv_after_convert: false
+#  当 custom_commandline 的值 不为空时，convert_to_mp4 的值会被无视，
+#  而是在录制结束后直接执行 custom_commandline 中的命令。
+#  在 custom_commandline 执行结束后，程序还会继续查看 delete_flv_after_convert 的值，
+#  来判断是否需要删除原始 flv 文件。
+#  以下是一个在录制结束后将 flv 视频转换为同名 mp4 视频的示例：
+#  custom_commandline: '{{ .Ffmpeg }} -hide_banner -i "{{ .FileName }}" -c copy "{{ .FileName | trimSuffix (.FileName | ext)}}.mp4"'
+  custom_commandline: ""
 timeout_in_us: 60000000

--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -50,8 +50,9 @@ type VideoSplitStrategies struct {
 
 // On record finished actions.
 type OnRecordFinished struct {
-	ConvertToMp4          bool `yaml:"convert_to_mp4"`
-	DeleteFlvAfterConvert bool `yaml:"delete_flv_after_convert"`
+	ConvertToMp4          bool   `yaml:"convert_to_mp4"`
+	DeleteFlvAfterConvert bool   `yaml:"delete_flv_after_convert"`
+	CustomCommandline     string `yaml:"custom_commandline"`
 }
 
 type Log struct {


### PR DESCRIPTION
Assign #522

对于用户输入参数使用了sh/cmd执行主要出于两个方向考虑：
1、对于用户来说相对符合习惯，即sh/cmd环境下可以正常执行的命令，就应该是符合预期的。
2、对于用户输入的字符串参数不能简单的通过空格分隔，得到一个参数列表，交付给`exec.Command`，因为很可能出现这样的命令行调用：`some_command -i "a b c"`