### PR TITLE
feat: 新增ffmpeg文件分片功能

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -25,6 +25,8 @@ out_put_tmpl: ""
 video_split_strategies:
   on_room_name_changed: false
   max_duration: 0s
+  # 仅在 use_native_flv_parser=false 时生效
+  max_file_size: -1
 cookies: {}
 on_record_finished:
   convert_to_mp4: false

--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -46,6 +46,7 @@ type Feature struct {
 type VideoSplitStrategies struct {
 	OnRoomNameChanged bool          `yaml:"on_room_name_changed"`
 	MaxDuration       time.Duration `yaml:"max_duration"`
+	MaxFileSize       string        `yaml:"max_file_size"`
 }
 
 // On record finished actions.

--- a/src/pkg/parser/ffmpeg/ffmpeg.go
+++ b/src/pkg/parser/ffmpeg/ffmpeg.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hr3lxphr6j/bililive-go/src/instance"
 	"github.com/hr3lxphr6j/bililive-go/src/live"
 	"github.com/hr3lxphr6j/bililive-go/src/pkg/parser"
 	"github.com/hr3lxphr6j/bililive-go/src/pkg/utils"
@@ -124,6 +125,7 @@ func (p *Parser) Status() (map[string]string, error) {
 
 func (p *Parser) ParseLiveStream(ctx context.Context, url *url.URL, live live.Live, file string) (err error) {
 	ffmpegPath, err := utils.GetFFmpegPath(ctx)
+	MaxFileSize := instance.GetInstance(ctx).Config.VideoSplitStrategies.MaxFileSize
 	if err != nil {
 		return err
 	}
@@ -136,6 +138,7 @@ func (p *Parser) ParseLiveStream(ctx context.Context, url *url.URL, live live.Li
 		"-referer", live.GetRawUrl(),
 		"-rw_timeout", p.timeoutInUs,
 		"-i", url.String(),
+		"-fs", MaxFileSize,
 		"-c", "copy",
 		"-bsf:a", "aac_adtstoasc",
 		file,


### PR DESCRIPTION
# 新增ffmpeg文件分片功能
仅在 use_native_flv_parser=false 时生效，由于不会GO语言，不会弄原生flv解析器的分片功能。
示例
```yaml
video_split_strategies:
  on_room_name_changed: false
  max_duration: 0s
  # 禁用文件大小分片
  max_file_size: -1
  # 文件100M分片
  max_file_size: 100M
  # 文件1G分片
  max_file_size: 1G
```