### PR TITLE
fix: 填入url，点击确认或取消后，输入框没有清空的bug

### DIFF
--- a/src/webapp/src/component/add-room-dialog/index.tsx
+++ b/src/webapp/src/component/add-room-dialog/index.tsx
@@ -37,6 +37,7 @@ class AddRoomDialog extends React.Component<Props> {
                 this.setState({
                     visible: false,
                     confirmLoading: false,
+                    textView:''
                 });
                 this.props.refresh();
             })
@@ -45,6 +46,7 @@ class AddRoomDialog extends React.Component<Props> {
                 this.setState({
                     visible: false,
                     confirmLoading: false,
+                    textView:''
                 });
             })
     };
@@ -52,6 +54,7 @@ class AddRoomDialog extends React.Component<Props> {
     handleCancel = () => {
         this.setState({
             visible: false,
+            textView:''
         });
     };
 
@@ -62,7 +65,7 @@ class AddRoomDialog extends React.Component<Props> {
     }
 
     render() {
-        const { visible, confirmLoading, ModalText } = this.state;
+        const { visible, confirmLoading, ModalText,textView } = this.state;
         return (
             <div>
                 <Modal
@@ -72,7 +75,7 @@ class AddRoomDialog extends React.Component<Props> {
                     confirmLoading={confirmLoading}
                     onCancel={this.handleCancel}>
                     <p>{ModalText}</p>
-                    <Input size="large" placeholder="https://" onChange={this.textChange} />
+                    <Input size="large" value={textView} placeholder="https://" onChange={this.textChange} />
                 </Modal>
             </div>
         );


### PR DESCRIPTION
在填入直播间url，点击确认，或者点击了取消之后，再次点击添加房间时弹出的[添加直播间]对话框没有清空
![9324af5b420b8c64baea5090d924558](https://github.com/hr3lxphr6j/bililive-go/assets/54766956/fb174946-9699-4a8c-818c-df6b2eef97cf)

![1705170790126](https://github.com/hr3lxphr6j/bililive-go/assets/54766956/3f8747de-e250-4109-a551-ed9cfb599931)

![1705170859558](https://github.com/hr3lxphr6j/bililive-go/assets/54766956/30447de2-d3c5-44a2-ad3c-f6e49ca626c1)

