### PR TITLE
feat: 微博新增强制调整清晰度功能

### DIFF
--- a/src/live/weibolive/weibolive.go
+++ b/src/live/weibolive/weibolive.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 	"regexp"
+	"fmt"
 
 	"github.com/hr3lxphr6j/bililive-go/src/pkg/utils"
 	"github.com/hr3lxphr6j/requests"
@@ -87,10 +88,18 @@ func (l *Live) GetStreamUrls() (us []*url.URL, err error) {
 
 	streamurl := gjson.GetBytes(body, "data.live_origin_flv_url").String()
     queryParams := l.Url.Query()
-	reg, err := regexp.Compile(`_wb[\d]+avc\.flv`)
-    if err == nil {
-        streamurl = reg.ReplaceAllString(streamurl, "_wb" + queryParams.Get("q") + "avc.flv")
-    }
+	quality := queryParams.Get("q")
+	if quality != "" {
+		targetQuality := "_wb" + quality + "avc.flv"
+		reg, err := regexp.Compile(`_wb[\d]+avc\.flv`)
+		if err == nil && reg.MatchString(streamurl) {
+			streamurl = reg.ReplaceAllString(streamurl, targetQuality)
+		} else {
+			streamurl = strings.Replace(streamurl, ".flv", targetQuality, -1)
+		}
+		fmt.Println("weibo stream quality fixed: " + streamurl)
+	}
+	
 	return utils.GenUrls(streamurl)
 }
 

--- a/src/live/weibolive/weibolive.go
+++ b/src/live/weibolive/weibolive.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"regexp"
 
 	"github.com/hr3lxphr6j/bililive-go/src/pkg/utils"
 	"github.com/hr3lxphr6j/requests"
@@ -85,6 +86,11 @@ func (l *Live) GetStreamUrls() (us []*url.URL, err error) {
 	}
 
 	streamurl := gjson.GetBytes(body, "data.live_origin_flv_url").String()
+    queryParams := l.Url.Query()
+	reg, err := regexp.Compile(`_wb[\d]+avc\.flv`)
+    if err == nil {
+        streamurl = reg.ReplaceAllString(streamurl, "_wb" + queryParams.Get("q") + "avc.flv")
+    }
 	return utils.GenUrls(streamurl)
 }
 


### PR DESCRIPTION
通过在直播间链接中添加`?q=1080`参数，强制调整录制分辨率以解锁微博隐藏的画质。
参数`q`说明：参数值为画面规格，1080p对应1080，720p对应720，以此类推。
例如：`https://weibo.com/l/wblive/p/show/1022:2321325028216606687583?q=1080`