### PR TITLE
修改了config.yml存在与否的应对逻辑

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,34 +2,38 @@ FROM alpine
 
 ARG tag
 
-ENV WORKDIR="/srv/bililive"
-ENV OUTPUT_DIR="/srv/bililive" \
+ENV WORKDIR="/srv/bililive" \
+    OUTPUT_DIR="/srv/bililive" \
     CONF_DIR="/etc/bililive-go" \
-    PORT=8080
+    PORT=8080 \
+    PUID=0 \
+    PGID=0 \
+    UMASK=022
 
-ENV PUID=0 PGID=0 UMASK=022
-
-RUN mkdir -p $OUTPUT_DIR && \
-    mkdir -p $CONF_DIR && \
+RUN mkdir -p $OUTPUT_DIR $CONF_DIR && \
     apk update && \
-    apk --no-cache add ffmpeg libc6-compat curl su-exec tzdata && \
-    cp -r -f /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
+    apk add --no-cache ffmpeg libc6-compat curl su-exec tzdata && \
+    cp -r -f /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    rm -rf /var/cache/apk/*
 
-RUN sh -c "case $(arch) in aarch64) go_arch=arm64 ;; arm*) go_arch=arm ;; i386|i686) go_arch=386 ;; x86_64) go_arch=amd64;; esac && \
-    cd /tmp && curl -sSLO https://github.com/hr3lxphr6j/bililive-go/releases/download/$tag/bililive-linux-\${go_arch}.tar.gz && \
-    tar zxvf bililive-linux-\${go_arch}.tar.gz bililive-linux-\${go_arch} && \
-    chmod +x bililive-linux-\${go_arch} && \
-    mv ./bililive-linux-\${go_arch} /usr/bin/bililive-go && \
-    rm ./bililive-linux-\${go_arch}.tar.gz" && \
-    sh -c "if [ $tag != $(/usr/bin/bililive-go --version | tr -d '\n') ]; then return 1; fi"
+RUN set -ex; \
+    case $(arch) in \
+        aarch64) go_arch="arm64" ;; \
+        arm*) go_arch="arm" ;; \
+        i386|i686) go_arch="386" ;; \
+        x86_64) go_arch="amd64" ;; \
+    esac; \
+    curl -fsSLo bililive-linux-${go_arch}.tar.gz "https://github.com/hr3lxphr6j/bililive-go/releases/download/${tag}/bililive-linux-${go_arch}.tar.gz" && \
+    tar zxvf bililive-linux-${go_arch}.tar.gz && \
+    chmod +x bililive-linux-${go_arch} && \
+    mv bililive-linux-${go_arch} /usr/bin/bililive-go && \
+    rm -rf bililive-linux-${go_arch}.tar.gz /tmp/*
 
-COPY config.docker.yml $CONF_DIR/config.yml
-
+COPY config.yml /defaults/config.yml
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 VOLUME $OUTPUT_DIR
-
 EXPOSE $PORT
 
 WORKDIR ${WORKDIR}

--- a/README.md
+++ b/README.md
@@ -195,20 +195,60 @@ https://github.com/hr3lxphr6j/bililive-go/wiki/Install-Linux
 使用 https://hub.docker.com/r/chigusa/bililive-go 镜像创建容器运行。
 
 例如：
-```
-docker run --restart=always -v ~/config.yml:/etc/bililive-go/config.yml -v ~/Videos:/srv/bililive -p 8080:8080 -d chigusa/bililive-go
+```bash
+docker run -d \
+--name=bililive-go \
+--restart=unless-stopped \
+-p 8080:8080 \
+-v ~/bililive-go/config:/etc/bililive-go \
+-v ~/bililive-go/video:/srv/bililive \
+chigusa/bililive-go
 ```
 
 ### docker compose
-
-使用项目根目录下的 `docker-compose.yml` 配置文件启动 docker compose 运行。
-
-例如：
+创建 `vim docker-compose.yaml`
+```yaml
+version: '3.9'
+services:
+  bililive-go:
+    image: chigusa/bililive-go
+    container_name: bililive-go
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./config:/etc/bililive-go
+      - ./video:/srv/bililive
+    restart: unless-stopped
+```
+部署容器
 ```
 docker compose up
 ```
-此时默认使用 `config.docker.yml` 文件作为程序的配置文件，`Videos/` 目录作为录制视频的输出目录。
 
+<details>
+  <summary>进阶设置</summary>
+
+```bash
+# docker cli
+-e PUID=0 # 映射用户
+-e PGID=0 # 映射组
+```
+```yaml
+# docker compose
+    environment:
+      - PUID=0 # 映射用户
+      - PGID=0 # 映射组
+```
+`PUID` `PGID` 不建议为`0` 这将以`root`身份运行容器 一些情况下会对权限管理造成麻烦<br>
+使用非 `root` 用户运行容器是推荐的安全做法 可以通过运行 id "你的用户名" 来查找你的 `UID` 和 `GID` <br>
+```
+id "你的用户名"
+```
+会显示例如 `uid=1000` `gid=1000` 等信息
+  
+</details>
+
+### NAS
 NAS 用户使用系统自带 GUI 创建 docker compose 的情况请参考群晖用 docker compose 安装 bgo 的 [图文说明](./docs/Synology-related.md#如何用-docker-compose-安装-bgo)
 
 ## 常见问题

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,10 @@
 
 HOME=/srv/bililive
 
+if [ ! -f $CONF_DIR/config.yml ]; then
+    cp /defaults/config.yml $CONF_DIR/config.yml
+fi
+
 chown -R ${PUID}:${PGID} ${HOME}
 
 umask ${UMASK}


### PR DESCRIPTION
顺便调整了`Dockerfile`的格式 方便阅读
现在不需要1对1映射`config.yml`了 只要映射目录 比如 `~/bililive-go/config:/etc/bililive-go/`
就会在`~/bililive-go/config/` 下产生`config.yml`
事先也不需要创建`~/bililive-go` 等目录